### PR TITLE
Change prefix of remark command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -23,9 +23,9 @@ public class RemarkCommand extends Command {
             + "by the index number used in the last person listing. "
             + "Existing remark will be overwritten by the input.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "r/ [REMARK]\n"
+            + "-r [REMARK]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + "r/ Likes to swim.";
+            + "-r Likes to swim.";
 
     public static final String MESSAGE_NOT_IMPLEMENTED_YET =
             "Remark command not implemented yet";

--- a/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.Remark;
  */
 public class RemarkCommandParser implements Parser {
 
-    private static final Prefix PREFIX_REMARK = new Prefix("r/");
+    private static final Prefix PREFIX_REMARK = new Prefix("-r");
 
     /**
      * Parses the given {@code String} of arguments in the context of the RemarkCommand


### PR DESCRIPTION
Changed Remark Command prefix from `r/` to `-r`.

Closes #38 