### PR TITLE
Widen contact window, and made text wrap around

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -58,10 +58,15 @@ public class PersonCard extends UiPart<Region> {
 
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().getDisplayableName());
+        name.setWrapText(true);
         phone.setText(person.getPhone().getDisplayablePhone());
+        phone.setWrapText(true);
         address.setText(person.getAddress().getDisplayableAddress());
+        address.setWrapText(true);
         email.setText(person.getEmail().getDisplayableEmail());
+        email.setWrapText(true);
         remark.setText(person.getRemark().getDisplayableRemark());
+        remark.setWrapText(true);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -39,7 +39,7 @@
 
                 <HBox prefHeight="9999" styleClass="pane-with-border">
                     <!-- Person List -->
-                    <VBox fx:id="personList" minWidth="400" prefWidth="400" style="-fx-background-color: #343434;"
+                    <VBox fx:id="personList" minWidth="600" prefWidth="600" style="-fx-background-color: #343434;"
                           styleClass="pane-with-border" VBox.vgrow="ALWAYS" focusTraversable="true">
                         <padding>
                             <Insets bottom="10" left="10" right="10" top="10"/>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -39,7 +39,7 @@
 
                 <HBox prefHeight="9999" styleClass="pane-with-border">
                     <!-- Person List -->
-                    <VBox fx:id="personList" minWidth="600" prefWidth="600" style="-fx-background-color: #343434;"
+                    <VBox fx:id="personList" minWidth="400" prefWidth="400" style="-fx-background-color: #343434;"
                           styleClass="pane-with-border" VBox.vgrow="ALWAYS" focusTraversable="true">
                         <padding>
                             <Insets bottom="10" left="10" right="10" top="10"/>

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+    <ListView fx:id="personListView" VBox.vgrow="ALWAYS"/>
 </VBox>


### PR DESCRIPTION
Fixes #164 by making text wrap around. This fixes the bug of users not being able to see long words. However, this extends the person card down, and makes it a bit ugly if inputs are too long. We can put this under planned enhancements for long remarks.