### PR TITLE
Fix bug where data still persists after password delete

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -50,21 +51,24 @@ public class LogicManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
-        // Check if JSON file exists.
-        // This is to ensure export command works without initial JSON file.
-        File checkFile = new File(VBOOK_PATH);
-        if (!checkFile.exists()) {
-            try {
-                storage.saveAddressBook(model.getVersionedAddressBook());
-            } catch (AccessDeniedException e) {
-                throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
-            } catch (IOException ioe) {
-                throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
+        CommandResult commandResult;
+        Command command = addressBookParser.parseCommand(commandText);
+
+        if (command.equals(new ExportCommand())) {
+            // Check if JSON file exists.
+            // This is to ensure export command works without initial JSON file.
+            File checkFile = new File(VBOOK_PATH);
+            if (!checkFile.exists()) {
+                try {
+                    storage.saveAddressBook(model.getVersionedAddressBook());
+                } catch (AccessDeniedException e) {
+                    throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
+                } catch (IOException ioe) {
+                    throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
+                }
             }
         }
 
-        CommandResult commandResult;
-        Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -56,8 +56,10 @@ public class LogicManager implements Logic {
         if (!checkFile.exists()) {
             try {
                 storage.saveAddressBook(model.getVersionedAddressBook());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            } catch (AccessDeniedException e) {
+                throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
+            } catch (IOException ioe) {
+                throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
             }
         }
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -1,5 +1,6 @@
 package seedu.address.logic;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
@@ -27,11 +28,14 @@ public class LogicManager implements Logic {
     public static final String FILE_OPS_PERMISSION_ERROR_FORMAT =
             "Could not save data to file %s due to insufficient permissions to write to the file or the folder.";
 
+    private static final String VBOOK_PATH = "data/addressbook.json";
+
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
+
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -45,6 +49,17 @@ public class LogicManager implements Logic {
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
+
+        // Check if JSON file exists.
+        // This is to ensure export command works without initial JSON file.
+        File checkFile = new File(VBOOK_PATH);
+        if (!checkFile.exists()) {
+            try {
+                storage.saveAddressBook(model.getVersionedAddressBook());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
 
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -130,6 +130,15 @@ public class ExportCommand extends Command {
         return fileChooser.showSaveDialog(stage);
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (object == this) {
+            return true;
+        }
+
+        return object instanceof ExportCommand;
+    }
+
     public void setDestinationFile(File destinationFile) {
         this.destinationFile = destinationFile;
     }

--- a/src/main/java/seedu/address/security/PasswordManager.java
+++ b/src/main/java/seedu/address/security/PasswordManager.java
@@ -6,8 +6,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
@@ -40,7 +38,6 @@ public class PasswordManager {
 
         File file = new File(path);
         if (!file.exists()) {
-
             return null; // No password set
         }
 
@@ -90,13 +87,6 @@ public class PasswordManager {
 
         String storedPasswordHash = readPassword(path);
         if (storedPasswordHash == null) {
-            try {
-                Files.deleteIfExists(Path.of("data/addressbook.json"));
-                Files.deleteIfExists(Path.of(PASSWORD_FILE));
-            } catch (IOException ex) {
-                return false;
-            }
-
             return false; // No password set
         }
 

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -65,9 +65,6 @@ public class JsonAddressBookStorage implements AddressBookStorage {
                     Files.deleteIfExists(Path.of(PASSWORD_PATH));
                 } catch (IOException ex) {
                     ex.printStackTrace();
-                    // Directly return default address book
-                } finally {
-                    return Optional.empty();
                 }
             }
 

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,12 +27,14 @@ import seedu.address.security.EncryptionManager;
 public class JsonAddressBookStorage implements AddressBookStorage {
 
     private static final Logger logger = LogsCenter.getLogger(JsonAddressBookStorage.class);
-
+    private static final String PASSWORD_PATH = "password.txt";
     private Path filePath;
 
     public JsonAddressBookStorage(Path filePath) {
         this.filePath = filePath;
     }
+
+
 
     public Path getAddressBookFilePath() {
         return filePath;
@@ -52,6 +55,22 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         requireNonNull(filePath);
 
         try {
+            // Check if password file exists
+            File file = new File(PASSWORD_PATH);
+            if (!file.exists()) {
+                try {
+                    // Password file doesn't exist
+                    // Start with empty data
+                    Files.deleteIfExists(Path.of("data/addressbook.json"));
+                    Files.deleteIfExists(Path.of(PASSWORD_PATH));
+                } catch (IOException ex) {
+                    ex.printStackTrace();
+                    // Directly return default address book
+                } finally {
+                    return Optional.empty();
+                }
+            }
+
             byte[] encryptedData = Files.readAllBytes(filePath);
             String jsonData = EncryptionManager.decrypt(encryptedData, null);
             JsonSerializableAddressBook jsonAddressBook = JsonUtil.fromJsonString(

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -40,7 +40,7 @@ public class UiManager implements Ui {
         primaryStage.getIcons().add(getImage(ICON_APPLICATION));
 
         boolean passwordCorrect = PasswordPromptDialog.display(primaryStage);
-        System.out.println(passwordCorrect);
+
         if (!passwordCorrect) {
             // Exit the application if the password is incorrect
             Platform.exit();


### PR DESCRIPTION
Resolves #200 

# Changes made
- Moved `password.txt` existence check to `JsonAddressBookStorage.java` from `PasswordManager.java` as this is the initial point of entry where data is loaded.
    - For the above check, it immediately deletes the current `addressbook.json` file and returns the default `Optional.empty()` if `password.txt` does not exist
- In `LogicManager.java`, before parsing any command, added check for existence of `addressbook.json` file data. This is to handle the case where `:export` is the first command and no `addressbook.json` file exists to export. This happens when:
    - Initial load with no data
    - Subsequent loads but `password.txt` was deleted, so `addressbook.json` is also deleted on load
 - Removed debug message that checks if password is correct

# Manual tests to validate the above - tested on both Windows and Mac
- This bug fix ensures that data is deleted in both the GUI and `addressbook.json`
- The former is validated from the GUI while the latter by the Export Command
## Test 1 - Initial load. No `password.txt` and no `addressbook.json`
1. GUI shows default data on login
2. `:export` - exported data contains default `addressbook.json` data as expected
3. `:add -n Bob` - GUI shows Bob added
4. `:export` - exported data has Bob as expected

## Test 2 - Quit program after initial load. Delete `password.txt` file
1. GUI shows default data on login with new password creation
2. `:export` - exported data contains default `addressbook.json` data as expected
3. `:add -n Bob` - GUI shows Bob added
4. `:export` - exported data has Bob as expected
